### PR TITLE
fix when origin table name and table name different

### DIFF
--- a/src/modules.py
+++ b/src/modules.py
@@ -27,8 +27,12 @@ class BaseModule():
             cursor = conn.cursor()
             csv_dir = os.path.join(self.db_root_path,db_id,'database_description')
             otn_list = table_info['table_names_original']
-            for otn in otn_list:
-                csv_path = os.path.join(os.path.join(csv_dir, f"{otn}.csv"))
+            tn_list = table_info['table_names']
+            for otn,tn in zip(otn_list, tn_list):
+                if os.path.exists(os.path.join(csv_dir, f"{tn}.csv")):
+                    csv_path = os.path.join(os.path.join(csv_dir, f"{tn}.csv"))
+                else:
+                    csv_path = os.path.join(os.path.join(csv_dir, f"{otn}.csv"))
                 csv_dict = csv.DictReader(open(csv_path, newline='', encoding="latin1"))
                 column_info = {}
                 


### PR DESCRIPTION
in mini_dev dataset, a database **student_club**`s table name and origin name was different, causing runtime error
```
Traceback (most recent call last):
  File "./run.py", line 51, in <module>
    main(opt)
  File "./run.py", line 46, in main
    talog = TALOG(db_root_path, mode)
  File "/home/lzq/workspace/TA-SQL/src/modules.py", line 169, in __init__
    self.csv_info, self.value_prompts = self._get_info_from_csv()
  File "/home/lzq/workspace/TA-SQL/src/modules.py", line 36, in _get_info_from_csv
    csv_dict = csv.DictReader(open(csv_path, newline='', encoding="latin1"))
FileNotFoundError: [Errno 2] No such file or directory: './data/dev_databases/card_games/database_description/ruling.csv'
```
this PR will fix this condition to occur